### PR TITLE
kerosene-ui: Fix exports and bump version

### DIFF
--- a/packages/kerosene-ui/package.json
+++ b/packages/kerosene-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-ui",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/KablamoOSS/kerosene.git",

--- a/packages/kerosene-ui/src/index.ts
+++ b/packages/kerosene-ui/src/index.ts
@@ -1,4 +1,4 @@
-export { default as usInterval } from "./hooks/useInterval";
+export { default as useInterval } from "./hooks/useInterval";
 export { default as useKonamiCode } from "./hooks/useKonamiCode";
 export { default as usePopup } from "./hooks/usePopup";
 export { default as useRafThrottle } from "./hooks/useRafThrottle";
@@ -7,6 +7,8 @@ export { default as useRect } from "./hooks/useRect";
 export { default as ShowWhen } from "./ShowWhen";
 
 export { default as getSafeAreaInsets } from "./utils/getSafeAreaInsets";
+import { SafeAreaInsets as _SafeAreaInsets } from "./utils/getSafeAreaInsets";
+export type SafeAreaInsets = _SafeAreaInsets;
 export { default as getTextWidth } from "./utils/getTextWidth";
 import { FontDetails as _FontDetails } from "./utils/getTextWidth";
 export type FontDetails = _FontDetails;


### PR DESCRIPTION
Fix `usInterval` -> `useInterval` typo.
Export `SafeAreaInsets`.