### PR TITLE
kerosene: Stricter typings for product()

### DIFF
--- a/packages/kerosene/package.json
+++ b/packages/kerosene/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/KablamoOSS/kerosene.git",

--- a/packages/kerosene/src/array/product.ts
+++ b/packages/kerosene/src/array/product.ts
@@ -1,3 +1,35 @@
+export default function product(): [[]];
+
+export default function product<T1>(source1: T1[]): [T1][];
+
+export default function product<T1, T2>(
+  source1: T1[],
+  source2: T2[],
+): [T1, T2][];
+
+export default function product<T1, T2, T3>(
+  source1: T1[],
+  source2: T2[],
+  source3: T3[],
+): [T1, T2, T3][];
+
+export default function product<T1, T2, T3, T4>(
+  source1: T1[],
+  source2: T2[],
+  source3: T3[],
+  source4: T4[],
+): [T1, T2, T3, T4][];
+
+export default function product<T1, T2, T3, T4, T5>(
+  source1: T1[],
+  source2: T2[],
+  source3: T3[],
+  source4: T4[],
+  source5: T5[],
+): [T1, T2, T3, T4, T5][];
+
+export default function product<T>(...sources: T[][]): T[][];
+
 /**
  * Returns the cartesian product of the source arrays
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -831,16 +831,6 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@kablamo/kerosene@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@kablamo/kerosene/-/kerosene-0.0.6.tgz#df550c16a4ba56b8d819fb517d3902c371e32666"
-  integrity sha512-Qk7/goUpyVu962+fjjjDRmZMf67RYVdpe0FJMfjzMY4HKwFFGNb+BDlMlf/zDDEUAJhU8VUZa+XkdXJHp8tiUQ==
-  dependencies:
-    "@types/lodash" "^4.14.121"
-    content-type "^1.0.4"
-    core-js-pure "^3.1.3"
-    lodash "^4.17.11"
-
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78"


### PR DESCRIPTION
Adds some overload signatures for `product()` that provide stricter typings for consumers.
