### PR TITLE
kerosene: Add KeysWhere<T, TValue> utility type

### DIFF
--- a/packages/kerosene/package.json
+++ b/packages/kerosene/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/KablamoOSS/kerosene.git",

--- a/packages/kerosene/readme.md
+++ b/packages/kerosene/readme.md
@@ -214,6 +214,10 @@ Recursively traverses `T` to make all properties optional.
 
 Infers the element type `T` from `T[]`, `Set<T>` or `Map<any, T>`.
 
+### `KeysWhere<T, TValue>`
+
+Creates a union of all keys of `T` where `T[key]` has type `TValue`.
+
 ### `Mutable<T>`
 
 Removes the `readonly` modifier from all properties in `T`.

--- a/packages/kerosene/src/types/index.ts
+++ b/packages/kerosene/src/types/index.ts
@@ -1,9 +1,21 @@
+/**
+ * Make all nested properties of `T` `Required` and `NonNullable`
+ */
 export type DeepNonNullable<T> = {
-  [P in keyof T]-?: DeepNonNullable<NonNullable<T[P]>>
+  [P in keyof T]-?: DeepNonNullable<NonNullable<T[P]>>;
 };
 
+/**
+ * Make all nested properties of `T` optional
+ */
 export type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 
+/**
+ * Infers the element type `T` from `TCollection` where `TCollection` is one of:
+ * - `readonly T[]`
+ * - `Set<T>`
+ * - `Map<any, T>`
+ */
 export type ElementType<
   TCollection
 > = TCollection extends readonly (infer TArrayElement)[]
@@ -14,4 +26,14 @@ export type ElementType<
   ? TMapElement
   : never;
 
+/**
+ * Creates a union of all keys of `T` where `T[key]` has type `TValue`
+ */
+export type KeysWhere<T extends object, TValue extends unknown> = {
+  [Key in keyof T]: T extends { [key in Key]: TValue } ? Key : never;
+}[keyof T];
+
+/**
+ * Make all properties of `T` mutable
+ */
 export type Mutable<T> = { -readonly [P in keyof T]: T[P] };


### PR DESCRIPTION
Adds the `KeysWhere<T, TValue>` utlity type which creates a union of all keys of `T` where `T[key]` has type `TValue`.