### PR TITLE
kerosene: Add MergedUnion<T> type

### DIFF
--- a/packages/kerosene/package.json
+++ b/packages/kerosene/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/KablamoOSS/kerosene.git",

--- a/packages/kerosene/readme.md
+++ b/packages/kerosene/readme.md
@@ -218,6 +218,10 @@ Infers the element type `T` from `T[]`, `Set<T>` or `Map<any, T>`.
 
 Creates a union of all keys of `T` where `T[key]` has type `TValue`.
 
+### `MergedUnion<T>`
+
+From a union type `T`, allows properties which are not shared by all members to be `undefined`.
+
 ### `Mutable<T>`
 
 Removes the `readonly` modifier from all properties in `T`.

--- a/packages/kerosene/src/types/index.ts
+++ b/packages/kerosene/src/types/index.ts
@@ -34,6 +34,18 @@ export type KeysWhere<T extends object, TValue extends unknown> = {
 }[keyof T];
 
 /**
+ * From a union type `T`, allows properties which are not shared by all members to be `undefined`
+ *
+ * e.g.
+ * ```typescript
+ * type FooBar = MergedUnion<{ common: string; foo: string } | { common: string; bar: string }>;
+ * // equivalent to
+ * type FooBar = { common: string; foo: string; bar?: undefined } | { common: string; foo?: undefined; bar: string };
+ * ```
+ */
+export type MergedUnion<T extends {}> = { [key in keyof T]?: undefined } & T;
+
+/**
  * Make all properties of `T` mutable
  */
 export type Mutable<T> = { -readonly [P in keyof T]: T[P] };


### PR DESCRIPTION
Adds a `MergedUnion<T>` utility type that, from a union type `T`, allows properties which are not shared by all members to be `undefined`.
