### PR TITLE
kerosene: Add Entries<T> utility type, update ElementType<TCollection> to accept plain objects

### DIFF
--- a/packages/kerosene/package.json
+++ b/packages/kerosene/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/KablamoOSS/kerosene.git",

--- a/packages/kerosene/readme.md
+++ b/packages/kerosene/readme.md
@@ -212,7 +212,11 @@ Recursively traverses `T` to make all properties optional.
 
 ### `ElementType<TCollection>`
 
-Infers the element type `T` from `T[]`, `Set<T>` or `Map<any, T>`.
+Infers the element type `T` from `T[]`, `Set<T>`, `Map<any, T>`, or `{ [key: string]: T }`.
+
+### `Entries<T>`
+
+Infers the union of all object entry tuples for type `T`.
 
 ### `KeysWhere<T, TValue>`
 

--- a/packages/kerosene/src/types/index.ts
+++ b/packages/kerosene/src/types/index.ts
@@ -15,6 +15,7 @@ export type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
  * - `readonly T[]`
  * - `Set<T>`
  * - `Map<any, T>`
+ * - `{ [key: string]: T }`
  */
 export type ElementType<
   TCollection
@@ -24,7 +25,14 @@ export type ElementType<
   ? TSetElement
   : TCollection extends Map<any, infer TMapElement>
   ? TMapElement
+  : TCollection extends { readonly [key: string]: infer TObjectElement }
+  ? TObjectElement
   : never;
+
+/**
+ * Infers the union of all object entry tuples for type `T`
+ */
+export type Entries<T> = { [P in keyof T]: [P, T[P]] }[keyof T];
 
 /**
  * Creates a union of all keys of `T` where `T[key]` has type `TValue`


### PR DESCRIPTION
Adds an `Entries<T>` utility type which infers the union of all object entry tuples for type `T`.

Also updates `ElementType<TCollection>` to infer the value type for plain objects.