### PR TITLE
extend useRect to update for specified event

### DIFF
--- a/packages/kerosene-ui/package.json
+++ b/packages/kerosene-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-ui",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/KablamoOSS/kerosene.git",
@@ -25,7 +25,7 @@
     "node": ">= 6"
   },
   "dependencies": {
-    "@kablamo/kerosene": "^0.0.7"
+    "@kablamo/kerosene": "^0.0.11"
   },
   "devDependencies": {
     "react": "^16.8.6",

--- a/packages/kerosene-ui/src/hooks/useRect.spec.tsx
+++ b/packages/kerosene-ui/src/hooks/useRect.spec.tsx
@@ -89,4 +89,35 @@ describe("useRect", () => {
       capture: true,
     });
   });
+
+  it("should add and remove listeners for event specified", () => {
+    const Component = () => {
+      const [ref] = useRect(false, "transitionend");
+      return (
+        <div ref={ref as React.Ref<HTMLDivElement>}>
+          <StubComponent />
+        </div>
+      );
+    };
+    const root = mount(<Component />);
+    // hack to force useEffect() to trigger
+    root.setProps({});
+
+    expect(_addEventListener).toHaveBeenCalledWith(
+      "transitionend",
+      expect.any(Function),
+      { capture: true, passive: true },
+    );
+
+    const onTransitionEnd = _addEventListener.mock.calls.find(
+      args => args[0] === "transitionend",
+    )![1] as EventListener;
+
+    root.unmount();
+
+    expect(_removeEventListener).toHaveBeenCalledWith("transitionend", onTransitionEnd, {
+      capture: true,
+    });
+  });
+
 });

--- a/packages/kerosene-ui/src/hooks/useRect.spec.tsx
+++ b/packages/kerosene-ui/src/hooks/useRect.spec.tsx
@@ -90,7 +90,7 @@ describe("useRect", () => {
     });
   });
 
-  it("should add and remove listeners for event specified", () => {
+  it("should add and remove listeners for events specified", () => {
     const Component = () => {
       const [ref] = useRect(false, ["transitionend"]);
       return (
@@ -108,14 +108,25 @@ describe("useRect", () => {
       expect.any(Function),
       { capture: true, passive: true },
     );
+    expect(_addEventListener).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+      { capture: true, passive: true },
+    );
 
     const onTransitionEnd = _addEventListener.mock.calls.find(
       args => args[0] === "transitionend",
+    )![1] as EventListener;
+    const onScroll = _addEventListener.mock.calls.find(
+      args => args[0] === "scroll",
     )![1] as EventListener;
 
     root.unmount();
 
     expect(_removeEventListener).toHaveBeenCalledWith("transitionend", onTransitionEnd, {
+      capture: true,
+    });
+    expect(_removeEventListener).toHaveBeenCalledWith("scroll", onScroll, {
       capture: true,
     });
   });

--- a/packages/kerosene-ui/src/hooks/useRect.spec.tsx
+++ b/packages/kerosene-ui/src/hooks/useRect.spec.tsx
@@ -92,7 +92,7 @@ describe("useRect", () => {
 
   it("should add and remove listeners for event specified", () => {
     const Component = () => {
-      const [ref] = useRect(false, "transitionend");
+      const [ref] = useRect(false, ["transitionend"]);
       return (
         <div ref={ref as React.Ref<HTMLDivElement>}>
           <StubComponent />

--- a/packages/kerosene-ui/src/hooks/useRect.ts
+++ b/packages/kerosene-ui/src/hooks/useRect.ts
@@ -25,11 +25,11 @@ const DEFAULT_RECT: Rect = {
 /**
  * Custom React Hook for reading bounding rect of a DOM Element
  * @param disable When set to `true`, updating the rect will be disabled
- * @param event Listens for specified event type and triggers update, default is "scroll"
+ * @param eventList Listens for specified event types and triggers update
  */
 export default function useRect(
   disable = false,
-  event = "scroll",
+  eventList: (keyof WindowEventMap)[] = [],
 ): [React.RefObject<Element>, Rect, ScrollPosition] {
   const ref = React.useRef<Element>(null);
   const [rect, setRect] = React.useState(DEFAULT_RECT);
@@ -37,6 +37,7 @@ export default function useRect(
     scrollX: 0,
     scrollY: 0,
   });
+  const events = ["scroll", ...eventList];
 
   const update = useRafThrottle(() => {
     const newRect = ref.current
@@ -58,19 +59,23 @@ export default function useRect(
   React.useEffect(() => {
     if (!disable) {
       window.addEventListener("resize", update);
-      window.addEventListener(
-        event,
-        update,
-        ADD_EVENT_LISTENER_CAPTURE_PASSIVE_OPTIONS,
+      events.forEach(event =>
+        window.addEventListener(
+          event,
+          update,
+          ADD_EVENT_LISTENER_CAPTURE_PASSIVE_OPTIONS,
+        )
       );
     }
 
     return () => {
       window.removeEventListener("resize", update);
-      window.removeEventListener(
-        event,
-        update,
-        REMOVE_EVENT_LISTENER_CAPTURE_PASSIVE_OPTIONS,
+      events.forEach(event =>
+        window.removeEventListener(
+          event,
+          update,
+          REMOVE_EVENT_LISTENER_CAPTURE_PASSIVE_OPTIONS,
+        )
       );
     };
   }, [disable, update]);

--- a/packages/kerosene-ui/src/hooks/useRect.ts
+++ b/packages/kerosene-ui/src/hooks/useRect.ts
@@ -25,9 +25,11 @@ const DEFAULT_RECT: Rect = {
 /**
  * Custom React Hook for reading bounding rect of a DOM Element
  * @param disable When set to `true`, updating the rect will be disabled
+ * @param event Listens for specified event type and triggers update, default is "scroll"
  */
 export default function useRect(
   disable = false,
+  event = "scroll",
 ): [React.RefObject<Element>, Rect, ScrollPosition] {
   const ref = React.useRef<Element>(null);
   const [rect, setRect] = React.useState(DEFAULT_RECT);
@@ -57,7 +59,7 @@ export default function useRect(
     if (!disable) {
       window.addEventListener("resize", update);
       window.addEventListener(
-        "scroll",
+        event,
         update,
         ADD_EVENT_LISTENER_CAPTURE_PASSIVE_OPTIONS,
       );
@@ -66,7 +68,7 @@ export default function useRect(
     return () => {
       window.removeEventListener("resize", update);
       window.removeEventListener(
-        "scroll",
+        event,
         update,
         REMOVE_EVENT_LISTENER_CAPTURE_PASSIVE_OPTIONS,
       );


### PR DESCRIPTION
useRect is a custom hook for reading the bounding rect of an element
We are using the bounding rect of a component to resize an svg within it
The rect was only updating on window resize and scroll events, we needed our component to update and resize after css transitions on the page
This PR extends useRect() so we can specify events like "transitionend" to trigger and update