### PR TITLE
Add Display Name to the underlying DOM

### DIFF
--- a/packages/kerosene-test/package.json
+++ b/packages/kerosene-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-test",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/KablamoOSS/kerosene.git",
@@ -9,8 +9,7 @@
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"
   },
-  "contributors": [
-    {
+  "contributors": [{
       "name": "Kablamo",
       "url": "https://www.kablamo.com.au"
     },
@@ -18,6 +17,11 @@
       "name": "Nathan Hardy",
       "email": "nathan.hardy@kablamo.com.au",
       "url": "https://nhardy.id.au"
+    },
+    {
+      "name": "George El-Khoury",
+      "email": "george.elkhoury@kablamo.com.au",
+      "url": "https://gekdesign.com.au"
     }
   ],
   "homepage": "https://github.com/KablamoOSS/kerosene",

--- a/packages/kerosene-test/src/react/createStubComponent.tsx
+++ b/packages/kerosene-test/src/react/createStubComponent.tsx
@@ -61,7 +61,7 @@ export default function createStubComponent<
   if (functional) {
     return Object.assign(
       ({ children, ...props }: Props) => (
-        <div {...props}>
+        <div __displayName__={displayName} {...props}>
           {typeof children === "function"
             ? transformRenderPropResult(children(...getRenderProps!()))
             : (children as React.ReactNode)}
@@ -78,7 +78,7 @@ export default function createStubComponent<
       const { children, ...props } = this.props;
 
       return (
-        <div {...props}>
+        <div __displayName__={displayName} {...props}>
           {typeof children === "function"
             ? transformRenderPropResult((children as (
                 ...args: RenderProps


### PR DESCRIPTION
This is useful for snapshot testing, where only the underlying DOM is represented. This will ensure that the correct component is rendered once compared to the snapshot.