### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -49,7 +49,8 @@ jobs:
 
   release:
     name: Release
-    if: github.ref == 'master'
+    needs: build
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
~~I think `needs` was required in order for more than one job to run.~~

`if: github.ref == 'refs/heads/master'` was required