### PR TITLE
kerosene-test: Fix publishing .dist

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "scripts": {
     "build": "exit 0",
+    "clean": "exit 0",
     "test": "src/test.js"
   },
   "peerDependencies": {

--- a/packages/kerosene-feature-flags/.npmignore
+++ b/packages/kerosene-feature-flags/.npmignore
@@ -1,4 +1,3 @@
 __snapshots__
-
 **.spec.ts
 **.spec.tsx

--- a/packages/kerosene-styles/.npmignore
+++ b/packages/kerosene-styles/.npmignore
@@ -1,0 +1,3 @@
+__snapshots__
+**.spec.ts
+**.spec.tsx

--- a/packages/kerosene-test/.npmignore
+++ b/packages/kerosene-test/.npmignore
@@ -1,0 +1,3 @@
+__snapshots__
+**.spec.ts
+**.spec.tsx

--- a/packages/kerosene-test/package.json
+++ b/packages/kerosene-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-test",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene-test",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"

--- a/packages/kerosene-ui/.npmignore
+++ b/packages/kerosene-ui/.npmignore
@@ -1,0 +1,3 @@
+__snapshots__
+**.spec.ts
+**.spec.tsx

--- a/packages/kerosene/.npmignore
+++ b/packages/kerosene/.npmignore
@@ -1,0 +1,3 @@
+__snapshots__
+**.spec.ts
+**.spec.tsx


### PR DESCRIPTION
It looks like the last release of `@kablamo/kerosene-test` was missing the `.dist` folder due to `@changsets/cli` not accounting for the `.npmignore` file at a top level (which should have overridden the `.gitignore` file).

Bumping the version should trigger a re-publish with the correct files, and future publishes of other packages should happen correctly.