### PR TITLE
kerosene-ui: Make UnwrapComponent utlity type actually recursive

### DIFF
--- a/packages/kerosene-ui/package.json
+++ b/packages/kerosene-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-ui",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene-ui",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"

--- a/packages/kerosene-ui/src/types/index.ts
+++ b/packages/kerosene-ui/src/types/index.ts
@@ -1,34 +1,21 @@
 /**
- * Used internally by `UnwrapComponent<T>` to unwrap a single layer decorator-wrapped component
- * @private
- */
-export type _UnwrapComponent<T> = T extends React.MemoExoticComponent<
-  infer TMemoComponent
->
-  ? TMemoComponent
-  : T extends React.LazyExoticComponent<infer TLazyComponent>
-  ? TLazyComponent
-  : "WrappedComponent" extends keyof T
-  // @ts-ignore
-  ? T["WrappedComponent"]
-  : T;
-
-/**
  * Unwraps the decorated typings from a decorator-wrapped components to provide the original type of the underlying
  * component. Useful in unit testing when stubbing decorators with the identity function.
- *
- * Note: This will unwrap up to 8 layers of decorators as although TypeScript supports recursive types, it does not
- * allow recursive type arguments. If more levels are required, you may use the `_UnwrapComponent<T>` type to unwrap
- * a single layer at a time.
  */
-export type UnwrapComponent<T> = _UnwrapComponent<
-  _UnwrapComponent<
-    _UnwrapComponent<
-      _UnwrapComponent<
-        _UnwrapComponent<
-          _UnwrapComponent<_UnwrapComponent<_UnwrapComponent<T>>>
-        >
-      >
-    >
-  >
->;
+export type UnwrapComponent<T> = T extends React.MemoExoticComponent<
+  infer TMemoComponent
+>
+  ? { 0: UnwrapComponent<TMemoComponent> }[TMemoComponent extends any
+      ? 0
+      : never]
+  : T extends React.LazyExoticComponent<infer TLazyComponent>
+  ? { 0: UnwrapComponent<TLazyComponent> }[TLazyComponent extends any
+      ? 0
+      : never]
+  : "WrappedComponent" extends keyof T
+  ? {
+      // @ts-ignore
+      0: UnwrapComponent<T["WrappedComponent"]>;
+      // @ts-ignore
+    }[T["WrappedComponent"] extends any ? 0 : never]
+  : T;


### PR DESCRIPTION
Read about this technique in the discussion for TypeScript's new `awaited` type operator when they were considering just a utility type: https://github.com/microsoft/TypeScript/pull/35998

This appears to trick TS into lazily evaluating the types which avoids infinite recursion, which isn't permitted.