### PR TITLE
kerosene: fix circular dependency

### DIFF
--- a/packages/kerosene-ui/package.json
+++ b/packages/kerosene-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-ui",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene-ui",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"
@@ -21,7 +21,7 @@
     "node": ">= 10"
   },
   "dependencies": {
-    "@kablamo/kerosene": "^0.0.15"
+    "@kablamo/kerosene": "^0.0.16"
   },
   "devDependencies": {
     "react": "^16.13.1",

--- a/packages/kerosene/package.json
+++ b/packages/kerosene/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"

--- a/packages/kerosene/src/datetime/constants.ts
+++ b/packages/kerosene/src/datetime/constants.ts
@@ -1,0 +1,36 @@
+export const SECOND = 1_000;
+
+export const MINUTE = 60 * SECOND;
+
+export const HOUR = 60 * MINUTE;
+
+export const DAY = 24 * HOUR;
+
+export const DAYS_PER_WEEK = 7;
+
+export const MONTHS_PER_YEAR = 12;
+
+export enum Month {
+  JANUARY = 0,
+  FEBRUARY,
+  MARCH,
+  APRIL,
+  MAY,
+  JUNE,
+  JULY,
+  AUGUST,
+  SEPTEMBER,
+  OCTOBER,
+  NOVEMBER,
+  DECEMBER,
+}
+
+export enum DayOfWeek {
+  SUNDAY = 0,
+  MONDAY,
+  TUESDAY,
+  WEDNESDAY,
+  THURSDAY,
+  FRIDAY,
+  SATURDAY,
+}

--- a/packages/kerosene/src/datetime/getCalendarWeeks.ts
+++ b/packages/kerosene/src/datetime/getCalendarWeeks.ts
@@ -1,6 +1,6 @@
 import * as dateFns from "date-fns";
 import { range } from "lodash";
-import { DAYS_PER_WEEK, DayOfWeek } from ".";
+import { DAYS_PER_WEEK, DayOfWeek } from "./constants";
 
 /**
  * 7-tuple containing moments for each day of the calendar week
@@ -20,7 +20,7 @@ export type CalendarWeeks =
       CalendarWeek,
       CalendarWeek,
       CalendarWeek,
-      CalendarWeek
+      CalendarWeek,
     ];
 
 /**

--- a/packages/kerosene/src/datetime/index.ts
+++ b/packages/kerosene/src/datetime/index.ts
@@ -1,40 +1,4 @@
-export const SECOND = 1_000;
-
-export const MINUTE = 60 * SECOND;
-
-export const HOUR = 60 * MINUTE;
-
-export const DAY = 24 * HOUR;
-
-export const DAYS_PER_WEEK = 7;
-
-export const MONTHS_PER_YEAR = 12;
-
-export enum Month {
-  JANUARY = 0,
-  FEBRUARY,
-  MARCH,
-  APRIL,
-  MAY,
-  JUNE,
-  JULY,
-  AUGUST,
-  SEPTEMBER,
-  OCTOBER,
-  NOVEMBER,
-  DECEMBER,
-}
-
-export enum DayOfWeek {
-  SUNDAY = 0,
-  MONDAY,
-  TUESDAY,
-  WEDNESDAY,
-  THURSDAY,
-  FRIDAY,
-  SATURDAY,
-}
-
+export * from "./constants";
 export { default as getCalendarWeeks } from "./getCalendarWeeks";
 import {
   CalendarWeek as _CalendarWeek,


### PR DESCRIPTION
~~Depending on kerosene seemed to blow up the CRA minifier due to circular dependencies in sourcemaps~~. This turned out to be a red herring and CRA was just choking on source maps inside node_modules in general. Found an actual workaround here https://github.com/facebook/create-react-app/issues/8071#issuecomment-566257193