### PR TITLE
kerosene: Add overload utility types

### DIFF
--- a/packages/kerosene-test/package.json
+++ b/packages/kerosene-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-test",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene-test",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"
@@ -46,6 +46,7 @@
     "utils"
   ],
   "dependencies": {
+    "@kablamo/kerosene": "^0.0.28",
     "@types/lodash": "^4.14.184",
     "@types/sinon": "^10.0.13",
     "lodash": "^4.17.21",

--- a/packages/kerosene-test/readme.md
+++ b/packages/kerosene-test/readme.md
@@ -34,21 +34,21 @@ Stubs `properties` on the `target` object, and returns a function which restores
 
 #### `JestMock<T>`
 
-Shorthand for `jest.Mock<ReturnType<T>, Parameters<T>>;`.
+Shorthand for `jest.Mock<OverloadedReturnType<T>, OverloadedParameters<T>> & T;`.
 
 #### `JestSpied<T>`
 
-Shorthand for `jest.SpyInstance<ReturnType<T>, Parameters<T>>;`.
+Shorthand for `jest.SpyInstance<OverloadedReturnType<T>, OverloadedParameters<T>> & T;`.
 
 ### Sinon
 
 #### `SinonSpied<T>`
 
-Shorthand for `sinon.SinonSpy<Parameters<T>, ReturnType<T>>;`.
+Shorthand for `sinon.SinonSpy<OverloadedParameters<T>, OverloadedReturnType<T>> & T;`.
 
 #### `SinonStubbed<T>`
 
-Shorthand for `sinon.SinonStub<Parameters<T>, ReturnType<T>>;`.
+Shorthand for `sinon.SinonStub<OverloadedParameters<T>, OverloadedReturnType<T>> & T;`.
 
 ---
 

--- a/packages/kerosene-test/src/jest/index.ts
+++ b/packages/kerosene-test/src/jest/index.ts
@@ -1,17 +1,22 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import type {
+  OverloadedParameters,
+  OverloadedReturnType,
+} from "@kablamo/kerosene";
 
 /**
- * Shorthand for `jest.Mock<ReturnType<T>, Parameters<T>>;`
+ * Shorthand for `jest.Mock<OverloadedReturnType<T>, OverloadedParameters<T>> & T;`
  */
-export type JestMock<T extends (...args: any[]) => any> = jest.Mock<
-  ReturnType<T>,
-  Parameters<T>
->;
+export type JestMock<T> = jest.Mock<
+  OverloadedReturnType<T>,
+  OverloadedParameters<T>
+> &
+  T;
 
 /**
- * Shorthand for `jest.SpyInstance<ReturnType<T>, Parameters<T>>;`
+ * Shorthand for `jest.SpyInstance<OverloadedReturnType<T>, OverloadedParameters<T>> & T;`
  */
-export type JestSpied<T extends (...args: any[]) => any> = jest.SpyInstance<
-  ReturnType<T>,
-  Parameters<T>
->;
+export type JestSpied<T> = jest.SpyInstance<
+  OverloadedReturnType<T>,
+  OverloadedParameters<T>
+> &
+  T;

--- a/packages/kerosene-test/src/sinon/index.ts
+++ b/packages/kerosene-test/src/sinon/index.ts
@@ -1,19 +1,23 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
+import type {
+  OverloadedParameters,
+  OverloadedReturnType,
+} from "@kablamo/kerosene";
 import type * as sinon from "sinon";
 
 /**
- * Shorthand for `sinon.SinonSpy<Parameters<T>, ReturnType<T>>;`
+ * Shorthand for `sinon.SinonSpy<OverloadedParameters<T>, OverloadedReturnType<T>> & T;`
  */
-export type SinonSpied<T extends (...args: any[]) => any> = sinon.SinonSpy<
-  Parameters<T>,
-  ReturnType<T>
->;
+export type SinonSpied<T> = sinon.SinonSpy<
+  OverloadedParameters<T>,
+  OverloadedReturnType<T>
+> &
+  T;
 
 /**
- * Shorthand for `sinon.SinonStub<Parameters<T>, ReturnType<T>>;`
+ * Shorthand for `sinon.SinonStub<OverloadedParameters<T>, OverloadedReturnType<T>> & T;`
  */
-export type SinonStubbed<T extends (...args: any[]) => any> = sinon.SinonStub<
-  Parameters<T>,
-  ReturnType<T>
->;
+export type SinonStubbed<T> = sinon.SinonStub<
+  OverloadedParameters<T>,
+  OverloadedReturnType<T>
+> &
+  T;

--- a/packages/kerosene-ui/package.json
+++ b/packages/kerosene-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-ui",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene-ui",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"
@@ -22,12 +22,12 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.9",
-    "@kablamo/kerosene": "^0.0.27",
+    "@kablamo/kerosene": "^0.0.28",
     "@types/lodash": "^4.14.184",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@kablamo/kerosene-test": "^0.0.10",
+    "@kablamo/kerosene-test": "^0.0.11",
     "@rollup/plugin-babel": "^5.3.1",
     "@sinonjs/fake-timers": "^9.1.2",
     "@testing-library/dom": "^8.17.1",

--- a/packages/kerosene/package.json
+++ b/packages/kerosene/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"

--- a/packages/kerosene/readme.md
+++ b/packages/kerosene/readme.md
@@ -262,6 +262,22 @@ From a union type `T`, allows properties which are not shared by all members to 
 
 Removes the `readonly` modifier from all properties in `T`.
 
+### `Overloads<T>`
+
+From an overloaded function `T`, infer each overload as a tuple element.
+
+### `OverloadedParameters<T>`
+
+For an overloaded function `T`, infer the union of parameters for all overloads.
+
+### `OverloadedReturnType<T>`
+
+For an overloaded function `T`, infer the union of return types for all overloads.
+
+### `OverloadedReturnTypeWhen<T, P>`
+
+For an overloaded function `T`, infer the return type for the specific overload when parameters match `P`.
+
 ### `PickBy<T, TValue>`
 
 Creates a new type from `T` including only keys where the value is assignable to type `TValue`.

--- a/packages/kerosene/src/types/index.ts
+++ b/packages/kerosene/src/types/index.ts
@@ -103,6 +103,85 @@ export type MergedUnion<T extends object> = __MergedUnion__<T, T>;
 export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 
 /**
+ * From an overloaded function `T`, infer each overload as a tuple element
+ */
+export type Overloads<T> = T extends {
+  (...args: infer P1): infer R1;
+  (...args: infer P2): infer R2;
+  (...args: infer P3): infer R3;
+  (...args: infer P4): infer R4;
+  (...args: infer P5): infer R5;
+  (...args: infer P6): infer R6;
+}
+  ? [
+      (...args: P1) => R1,
+      (...args: P2) => R2,
+      (...args: P3) => R3,
+      (...args: P4) => R4,
+      (...args: P5) => R5,
+      (...args: P6) => R6,
+    ]
+  : T extends {
+      (...args: infer P1): infer R1;
+      (...args: infer P2): infer R2;
+      (...args: infer P3): infer R3;
+      (...args: infer P4): infer R4;
+      (...args: infer P5): infer R5;
+    }
+  ? [
+      (...args: P1) => R1,
+      (...args: P2) => R2,
+      (...args: P3) => R3,
+      (...args: P4) => R4,
+      (...args: P5) => R5,
+    ]
+  : T extends {
+      (...args: infer P1): infer R1;
+      (...args: infer P2): infer R2;
+      (...args: infer P3): infer R3;
+      (...args: infer P4): infer R4;
+    }
+  ? [
+      (...args: P1) => R1,
+      (...args: P2) => R2,
+      (...args: P3) => R3,
+      (...args: P4) => R4,
+    ]
+  : T extends {
+      (...args: infer P1): infer R1;
+      (...args: infer P2): infer R2;
+      (...args: infer P3): infer R3;
+    }
+  ? [(...args: P1) => R1, (...args: P2) => R2, (...args: P3) => R3]
+  : T extends {
+      (...args: infer P1): infer R1;
+      (...args: infer P2): infer R2;
+    }
+  ? [(...args: P1) => R1, (...args: P2) => R2]
+  : T extends (...args: infer P1) => infer R1
+  ? [(...args: P1) => R1]
+  : never;
+
+/**
+ * For an overloaded function `T`, infer the union of parameters for all overloads
+ */
+export type OverloadedParameters<T> = Parameters<Overloads<T>[number]>;
+
+/**
+ * For an overloaded function `T`, infer the union of return types for all overloads
+ */
+export type OverloadedReturnType<T> = ReturnType<Overloads<T>[number]>;
+
+/**
+ * For an overloaded function `T`, infer the return type for the specific overload when parameters match `P`
+ */
+export type OverloadedReturnTypeWhen<T, P extends unknown[]> = T extends (
+  ...args: P
+) => infer R
+  ? R
+  : never;
+
+/**
  * Creates a new type from `T` including only keys where the value is assignable to type `TValue`
  */
 export type PickBy<T extends object, TValue> = {


### PR DESCRIPTION
Adds utility types for `Overloads<T>`, `OverloadedParameters<T>`, `OverloadedReturnType<T>`, `OverloadedReturnTypeWhen<T, P>`.