### PR TITLE
kerosene: deprecate parseSearch

### DIFF
--- a/packages/kerosene-ui/package.json
+++ b/packages/kerosene-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-ui",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene-ui",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.13",
-    "@kablamo/kerosene": "^0.0.19",
+    "@kablamo/kerosene": "^0.0.20",
     "@types/lodash": "^4.14.168",
     "lodash": "^4.17.20"
   },

--- a/packages/kerosene/package.json
+++ b/packages/kerosene/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"

--- a/packages/kerosene/readme.md
+++ b/packages/kerosene/readme.md
@@ -186,7 +186,9 @@ Returns `false` otherwise
 
 ### `parseSearch(search)`
 
-Uses `querystring.parse` to parse `Location#search`. When search is an empty string or contains no parameters, this will return an empty object.
+Deprecated in favour of `URLSearchParams`.
+
+See https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams or https://nodejs.org/api/url.html#url_class_urlsearchparams for documentation.
 
 ### `removeLineBreaks`
 

--- a/packages/kerosene/src/string/parseSearch.ts
+++ b/packages/kerosene/src/string/parseSearch.ts
@@ -1,6 +1,13 @@
-import * as qs from "querystring";
+// Using default import here due to faulty ESBuild polyfills with named exports
+import qs from "querystring";
+
 /**
  * Parse query parameters from Location.search
+ *
+ * @deprecated Use builtin `URLSearchParams(search)` instead
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
+ * @see https://nodejs.org/api/url.html#url_class_urlsearchparams
+ *
  * @param search Location.search
  */
 export default function parseSearch(search: string) {


### PR DESCRIPTION
Also replaces wildcard import of `querystring` with default import to work around faulty polyfill with ESBuild