### PR TITLE
eslint-config: Allow Emotion css prop

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -78,6 +78,8 @@ module.exports = {
       { allow: "always", extensions: [".tsx"] },
     ],
     "react/jsx-props-no-spreading": "off",
+    // Allow Emotion css prop
+    "react/no-unknown-property": ["error", { ignore: ["css"] }],
     // Not required with TypeScript
     "react/require-default-props": "off",
     "react/prop-types": "off",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/eslint-config",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "index.js",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/eslint-config",
   "bugs": {


### PR DESCRIPTION
Fixes error with `react/no-unknown-property` and Emotion `css` prop