### PR TITLE
kerosene: Fix waitForEventLoopToDrain breaking in Jest

### DIFF
--- a/packages/kerosene-ui/package.json
+++ b/packages/kerosene-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-ui",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene-ui",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.9",
-    "@kablamo/kerosene": "^0.0.26",
+    "@kablamo/kerosene": "^0.0.27",
     "@types/lodash": "^4.14.184",
     "lodash": "^4.17.21"
   },

--- a/packages/kerosene/package.json
+++ b/packages/kerosene/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"


### PR DESCRIPTION
Was previously thinking about using `package.json` exports to define something different for Node and the browser, but `jest-environment-jsdom` now uses the browser resolution for packages which rendered that approach no longer viable.

Instead, we can check for the presence of `jest.requireActual` if `globalThis.setImmediate` is not available to determine if we're in a jest environment, and require the actual, unstubbed Node [`timers`](https://nodejs.org/api/timers.html#setimmediatecallback-args) module. Thankfully, unlike `require`, `jest.requireActual` should be ignored by bundlers like `esbuild`, `webpack` and `rollup` and should not result in Node requires in code that is intended for browsers.