### PR TITLE
kerosene: Remove querystring dependency from parseSearch

### DIFF
--- a/packages/kerosene/rollup-config.ts
+++ b/packages/kerosene/rollup-config.ts
@@ -21,11 +21,9 @@ const output = (file: string, format: ModuleFormat): OutputOptions => ({
 });
 
 const externals = [
-  "querystring",
-  ...[packageJson.dependencies, packageJson.peerDependencies].flatMap(
-    Object.keys,
-  ),
-];
+  packageJson.dependencies,
+  packageJson.peerDependencies,
+].flatMap(Object.keys);
 
 const external: ExternalOption = (source) =>
   externals.includes(source) ||

--- a/packages/kerosene/src/string/parseSearch.ts
+++ b/packages/kerosene/src/string/parseSearch.ts
@@ -1,5 +1,7 @@
-// Using default import here due to faulty ESBuild polyfills with named exports
-import qs from "querystring";
+/**
+ * @deprecated Use builtin `URLSearchParams` instead
+ */
+type ParsedUrlQuery = NodeJS.Dict<string | string[]>;
 
 /**
  * Parse query parameters from Location.search
@@ -10,7 +12,17 @@ import qs from "querystring";
  *
  * @param search Location.search
  */
-export default function parseSearch(search: string) {
-  const [, querystring = ""] = search.split("?", 2);
-  return qs.parse(querystring);
+export default function parseSearch(search: string): ParsedUrlQuery {
+  const searchParams = new URLSearchParams(search);
+  const parsed: ParsedUrlQuery = Object.create(null);
+  searchParams.forEach((value, key) => {
+    if (typeof parsed[key] === "undefined") {
+      parsed[key] = value;
+    } else if (Array.isArray(parsed[key])) {
+      (parsed[key] as string[]).push(value);
+    } else {
+      parsed[key] = [parsed[key] as string, value];
+    }
+  });
+  return parsed;
 }


### PR DESCRIPTION
The dependency on `querystring` was causing deprecation notices to be included, even when consuming projects did not use the deprecated `parseSearch` function. As a result, this has been rewritten to be API-compatible but using the `URLSearchParams` as the parser to avoid the deprecation notice being included.

We should remove `parseSearch` entirely from a future version of `kerosene`.
