### PR TITLE
kerosene-ui: Add useLocalStorage hook, and use useSyncExternalStore for useMediaQuery, usePageVisibility

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,8 +16,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          # TODO: Remove after 2023-04-30
-          - lts/fermium
           - lts/gallium
           - lts/hydrogen
           - current

--- a/packages/kerosene-ui/package.json
+++ b/packages/kerosene-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-ui",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene-ui",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"
@@ -24,7 +24,8 @@
     "@babel/runtime": "^7.21.0",
     "@kablamo/kerosene": "^0.0.29",
     "@types/lodash": "^4.14.191",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "use-sync-external-store": "^1.2.0"
   },
   "devDependencies": {
     "@kablamo/kerosene-test": "^0.0.12",
@@ -34,6 +35,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/sinonjs__fake-timers": "^8.1.2",
+    "@types/use-sync-external-store": "^0.0.3",
     "jest-sandbox": "^1.1.2",
     "jest-when": "^3.5.2",
     "react": "^18.2.0",

--- a/packages/kerosene-ui/readme.md
+++ b/packages/kerosene-ui/readme.md
@@ -26,6 +26,10 @@ Custom hook which manages a series of `AbortController`s, aborting the previous 
 
 Custom hook which manages height transitions on the element that `ref` is applied to using `maxHeight`.
 
+### `useCurrentTime(period?)`
+
+Custom hook which uses a shared `CurrentTimeEmitter` class to listen for time updates in a performant way. Will update at least once every `period` milliseconds whilst the page is visible. Uses only a single interval to avoid overloading the browser when there are a large number of components listening to the time. Whilst this hook will attempt to updates components only as-required, it is not recommended to use this hook for extremely frequent updates (sub 1-second) and for such specific cases, `requestAnimationFrame` should be used instead.
+
 ### `useInterval(callback, delay)`
 
 Custom hook that makes `setInterval` work declaritively with hooks. See https://overreacted.io/making-setinterval-declarative-with-react-hooks/ for more details.
@@ -33,6 +37,10 @@ Custom hook that makes `setInterval` work declaritively with hooks. See https://
 ### `useKonamiCode(code, callback)`
 
 Custom hook which listens for keydown events for the specified `code` and triggers the callback when the code is entered.
+
+### `useLocalStorage(key, defaultValue, isT)`
+
+Custom hook which allows reading/writing of `localStorage` in a manner similar to `React.useState`.
 
 ### `useMediaQuery(query, { defaultMatches? }?)`
 

--- a/packages/kerosene-ui/src/hooks/useCurrentTime.spec.tsx
+++ b/packages/kerosene-ui/src/hooks/useCurrentTime.spec.tsx
@@ -1,0 +1,94 @@
+import { MINUTE, SECOND, waitForEventLoopToDrain } from "@kablamo/kerosene";
+import { act, renderHook } from "@testing-library/react";
+import { identity } from "lodash";
+import * as React from "react";
+import useCurrentTime, { CurrentTimeProvider } from "./useCurrentTime";
+
+const tick = (ms: number) =>
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+
+describe("useCurrentTime", () => {
+  let documentHidden: jest.SpyInstance<boolean, []>;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    documentHidden = jest.spyOn(document, "hidden", "get");
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("should return the current time and update every minute", () => {
+    const utils = renderHook(() => useCurrentTime());
+    expect(utils.result.current).toBe(Date.now());
+
+    tick(MINUTE);
+    expect(utils.result.current).toBe(Date.now());
+  });
+
+  it("should update at the interval supplied", () => {
+    const utils = renderHook(() => useCurrentTime(SECOND));
+    expect(utils.result.current).toBe(Date.now());
+
+    tick(SECOND);
+    expect(utils.result.current).toBe(Date.now());
+  });
+
+  it("should not update when not visible", () => {
+    const utils1 = renderHook(() => useCurrentTime());
+    const utils2 = renderHook(() => useCurrentTime());
+    expect(utils1.result.current).toBe(Date.now());
+    expect(utils2.result.current).toBe(Date.now());
+    documentHidden.mockReturnValue(true);
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    tick(MINUTE);
+    expect(utils1.result.current).not.toBe(Date.now());
+    expect(utils2.result.current).not.toBe(Date.now());
+
+    documentHidden.mockReturnValue(false);
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(utils1.result.current).toBe(Date.now());
+    expect(utils2.result.current).toBe(Date.now());
+  });
+
+  it("should emit events at the smallest period", async () => {
+    const utils1 = renderHook(() => useCurrentTime());
+    const utils2 = renderHook(() => useCurrentTime(SECOND));
+
+    tick(SECOND);
+    expect(utils1.result.current).not.toBe(Date.now());
+    expect(utils2.result.current).toBe(Date.now());
+
+    utils2.unmount();
+    await act(waitForEventLoopToDrain);
+    expect(utils1.result.current).toBe(Date.now());
+  });
+
+  it("should override defaults with context", () => {
+    const ssrTime = new Date("2000-01-01T01:23:45.678Z").getTime();
+    const useHistory: jest.Mock<number, [number]> = jest
+      .fn()
+      .mockImplementation(identity);
+    const utils = renderHook(() => useHistory(useCurrentTime()), {
+      hydrate: true,
+      wrapper: ({ children }) => (
+        <CurrentTimeProvider defaultPeriod={10 * SECOND} ssrTime={ssrTime}>
+          {children}
+        </CurrentTimeProvider>
+      ),
+    });
+    expect(useHistory).toHaveBeenCalledWith(ssrTime);
+    expect(utils.result.current).toBe(Date.now());
+
+    tick(10 * SECOND);
+    expect(utils.result.current).toBe(Date.now());
+  });
+});

--- a/packages/kerosene-ui/src/hooks/useCurrentTime.tsx
+++ b/packages/kerosene-ui/src/hooks/useCurrentTime.tsx
@@ -1,0 +1,222 @@
+import { MINUTE } from "@kablamo/kerosene";
+import * as React from "react";
+import { useSyncExternalStore } from "use-sync-external-store/shim";
+
+interface CurrentTimeSubscription {
+  lastUpdatedAt: number;
+  listener: () => void;
+  period: number;
+}
+
+class CurrentTimeEmitter {
+  private currentTime: number;
+
+  /**
+   * Stores the handler returned by `setInterval`
+   */
+  private interval?: number;
+
+  /**
+   * Stores the current interval period. Set to `Infinity` when no interval is active
+   */
+  private period = Infinity;
+
+  private subscribers: readonly CurrentTimeSubscription[] = [];
+
+  constructor(
+    /**
+     * Stores the time of initial render for SSR. The default here is probably not useful for SSR, so it is strongly
+     * recommended to use `<CurrentTimeProvider />` with an `ssrTime` when using SSR and hydration. But having a default
+     * means that use of the `useCurrentTime()` hook will not crash when using SSR.
+     */
+    private ssrTime = new Date("2000-01-01T00:00:00.000Z").getTime(),
+    /**
+     * Stores the default interval period which will be used if none is specified
+     */
+    private defaultPeriod = MINUTE,
+  ) {
+    this.currentTime = ssrTime;
+  }
+
+  /**
+   * `getSnapshot()` function used by `React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)`
+   */
+  public readonly getCurrentTime = () => this.currentTime;
+
+  /**
+   * `getServerSnapshot()` function used by `React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)`
+   */
+  public readonly getSsrTime = () => this.ssrTime;
+
+  /**
+   * Updates `this.currentTime` and calls all subscribers which need an update
+   */
+  private update = () => {
+    this.currentTime = Date.now();
+    this.subscribers
+      .filter(
+        ({ period, lastUpdatedAt }) =>
+          // Include subscribers which are within half their interval period of needing an update
+          this.currentTime >= lastUpdatedAt + period / 2,
+      )
+      .forEach((s) => {
+        // eslint-disable-next-line no-param-reassign
+        s.lastUpdatedAt = this.currentTime;
+        s.listener();
+      });
+  };
+
+  /**
+   * Mark all subscribers as requiring an update as soon as the next call to `this.update()`
+   */
+  private markAllForUpdate = () => {
+    // eslint-disable-next-line no-param-reassign
+    this.subscribers.forEach((s) => (s.lastUpdatedAt = 0));
+  };
+
+  /**
+   * Handles `document` `"visibilitychange"` events by disabling the interval whilst the document is hidden, and
+   * re-running updates when the page is resumed.
+   */
+  private onVisibilityChange = () => {
+    const { hidden = false } = document;
+
+    if (hidden) {
+      window.clearInterval(this.interval);
+      delete this.interval;
+    } else if (this.subscribers.length) {
+      this.period = Math.min(...this.subscribers.map((s) => s.period))!;
+      this.interval = window.setInterval(this.update, this.period);
+    }
+
+    this.markAllForUpdate();
+    this.update();
+  };
+
+  public readonly subscribe = (
+    listener: () => void,
+    period = this.defaultPeriod,
+  ) => {
+    if (!this.subscribers.length) {
+      // If there were previously no subscribers, start listening to the `"visibilitychange"` event
+      document.addEventListener("visibilitychange", this.onVisibilityChange);
+    }
+
+    // If the new period is less than the period of the currently operating interval
+    if (period < this.period) {
+      // Clear the existing interval
+      window.clearInterval(this.interval);
+      // Update to the more frequent period of this subscriber
+      this.period = period;
+      // Create a new interval with the updated period
+      this.interval = window.setInterval(this.update, this.period);
+    }
+
+    // Add the new subscriber
+    this.subscribers = [
+      ...this.subscribers,
+      { listener, period, lastUpdatedAt: 0 },
+    ];
+
+    this.update();
+
+    // Return a function which removes this subscription
+    return () => {
+      // Remove this subscription
+      this.subscribers = this.subscribers.filter(
+        (s) => s.listener !== listener,
+      );
+
+      // If there are no more subscribers after removing this one, we need to cleanup
+      if (!this.subscribers.length) {
+        // Clear the existing interval
+        window.clearInterval(this.interval);
+        delete this.interval;
+
+        // Set the period to indicate that there is no interval
+        this.period = Infinity;
+
+        // Remove the `"visibilitychange"` listener
+        document.removeEventListener(
+          "visibilitychange",
+          this.onVisibilityChange,
+        );
+      } else {
+        // Find the minimum period of the remaining listeners
+        const newPeriod = Math.min(...this.subscribers.map((s) => s.period));
+
+        // If the interval period needs updating
+        if (newPeriod !== this.period) {
+          // Clear the existing interval
+          window.clearInterval(this.interval);
+          this.period = newPeriod;
+
+          // Create a new interval with the updated period
+          this.interval = window.setInterval(this.update, this.period);
+
+          // Force an update soon, just in case the last interval was about to fire before it was cleared
+          this.markAllForUpdate();
+          Promise.resolve().then(() => this.update());
+        }
+      }
+    };
+  };
+}
+
+// Set up the context with a default `CurrentTimeEmitter` singleton so that the `useCurrentTime()` hook may be used
+// ergonimically without `<CurrentTimeProvider />` when there is no server side rendering
+const CurrentTimeEmitterContext = React.createContext(new CurrentTimeEmitter());
+
+/**
+ * Custom hook which uses a shared `CurrentTimeEmitter` class to listen for time updates in a performant way.
+ * Will update at least once every `period` milliseconds whilst the page is visible. Uses only a single interval to
+ * avoid overloading the browser when there are a large number of components listening to the time. Whilst this hook
+ * will attempt to updates components only as-required, it is not recommended to use this hook for extremely frequent
+ * updates (sub 1-second) and for such specific cases, `requestAnimationFrame` should be used instead.
+ * @param period Interval period
+ * @returns `currentTime`
+ */
+export default function useCurrentTime(period?: number): number {
+  const emitter = React.useContext(CurrentTimeEmitterContext);
+
+  const subscribe = React.useCallback(
+    (callback: () => void) => {
+      return emitter.subscribe(callback, period);
+    },
+    [emitter, period],
+  );
+
+  return useSyncExternalStore(
+    subscribe,
+    emitter.getCurrentTime,
+    emitter.getSsrTime,
+  );
+}
+
+export interface CurrentTimeProviderProps {
+  children?: React.ReactNode;
+  defaultPeriod?: number;
+  ssrTime?: number;
+}
+
+/**
+ * Context Provider for the CurrentTimeEmitter used internally by `useCurrentTime`.
+ * Recommended for use when using SSR so that on initial render and hydration a consistent and correct time will be used.
+ * @param props.children
+ * @param props.defaultPeriod
+ * @param props.ssrTime Unix epoch milliseconds for initial SSR render
+ */
+export const CurrentTimeProvider = ({
+  children,
+  defaultPeriod,
+  ssrTime,
+}: CurrentTimeProviderProps) => (
+  <CurrentTimeEmitterContext.Provider
+    value={React.useMemo(
+      () => new CurrentTimeEmitter(ssrTime, defaultPeriod),
+      [ssrTime, defaultPeriod],
+    )}
+  >
+    {children}
+  </CurrentTimeEmitterContext.Provider>
+);

--- a/packages/kerosene-ui/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/kerosene-ui/src/hooks/useIsomorphicLayoutEffect.ts
@@ -2,7 +2,8 @@ import * as React from "react";
 
 /**
  * Please avoid using this unless it is absolutely required. Most of the time, what you actually want is just
- * `React.useEffect()`.
+ * `React.useEffect()`, or may be accomplished more correctly with
+ * `React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)`.
  *
  * Most of the time `React.useEffect()` should be used if what you need doesn't need to happen before the render is
  * ready for the user, e.g. making a network call.
@@ -13,7 +14,9 @@ import * as React from "react";
  * intermediate state would be shown anyway before React finishes hydrating.
  *
  * But when moving between pages client side, you want to avoid an intermediate flash which could result after a change
- * in `React.useEffect()`, but not `React.useLayoutEffect()` (which is called synchronously after render).
+ * in `React.useEffect()`, but not `React.useLayoutEffect()` (which is called synchronously after render). It may also
+ * be worth checking whether `React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)` is a better fit
+ * for your use case, and would avoid a double render.
  */
 const useIsomorphicLayoutEffect =
   typeof window === "undefined" ? React.useEffect : React.useLayoutEffect;

--- a/packages/kerosene-ui/src/hooks/useLocalStorage.spec.tsx
+++ b/packages/kerosene-ui/src/hooks/useLocalStorage.spec.tsx
@@ -1,0 +1,95 @@
+import { act, renderHook } from "@testing-library/react";
+import { isBoolean } from "lodash";
+import useLocalStorage, {
+  type CustomStorageEventInit,
+} from "./useLocalStorage";
+
+const key = "key";
+
+describe("useLocalStorage", () => {
+  let _localStorage: Storage;
+  beforeEach(() => {
+    _localStorage = window.localStorage;
+  });
+
+  afterEach(() => {
+    window.localStorage = _localStorage;
+    window.localStorage.clear();
+  });
+
+  it("should return the defaultValue for server render", () => {
+    // @ts-expect-error
+    delete window.localStorage;
+    const { result } = renderHook(() => useLocalStorage(key, false, isBoolean));
+    expect(result.current[0]).toEqual(false);
+  });
+
+  it("should return the defaultValue", () => {
+    const { result } = renderHook(() => useLocalStorage(key, false, isBoolean));
+    expect(result.current[0]).toEqual(false);
+  });
+
+  it("should return a setValue function that updates localStorage", () => {
+    const { result } = renderHook(() => useLocalStorage(key, false, isBoolean));
+
+    // Plain update
+    act(() => {
+      result.current[1](true);
+    });
+    expect(result.current[0]).toEqual(true);
+    expect(localStorage.getItem(key)).toEqual(JSON.stringify(true));
+
+    // Updater function
+    act(() => {
+      result.current[1]((previous) => !previous);
+    });
+    expect(result.current[0]).toEqual(false);
+    expect(localStorage.getItem(key)).toEqual(JSON.stringify(false));
+  });
+
+  it("should return the value from localStorage", () => {
+    localStorage.setItem(key, JSON.stringify(true));
+    const { result } = renderHook(() => useLocalStorage(key, false, isBoolean));
+    expect(result.current[0]).toEqual(true);
+  });
+
+  it("should return the defaultValue when localStorage does not match the type", () => {
+    localStorage.setItem(key, JSON.stringify("true"));
+    const { result } = renderHook(() => useLocalStorage(key, false, isBoolean));
+    expect(result.current[0]).toEqual(false);
+  });
+
+  it.each([
+    {
+      name: "storage",
+      event: new StorageEvent("storage", {
+        key,
+        newValue: JSON.stringify(true),
+        oldValue: null,
+        storageArea: window.localStorage,
+      }),
+    },
+    {
+      name: "@kablamo/kerosene-ui/storage",
+      event: new CustomEvent<CustomStorageEventInit>(
+        "@kablamo/kerosene-ui/storage",
+        {
+          cancelable: false,
+          detail: {
+            key,
+            newValue: JSON.stringify(true),
+            storageArea: window.localStorage,
+          },
+        },
+      ),
+    },
+  ])("should update on '$name' event", ({ event }) => {
+    const { result } = renderHook(() => useLocalStorage(key, false, isBoolean));
+    expect(result.current[0]).toBe(false);
+    act(() => {
+      localStorage.setItem(key, JSON.stringify(true));
+      window.dispatchEvent(event);
+    });
+    expect(result.current[0]).toBe(true);
+  });
+});

--- a/packages/kerosene-ui/src/hooks/useLocalStorage.ts
+++ b/packages/kerosene-ui/src/hooks/useLocalStorage.ts
@@ -1,0 +1,116 @@
+import { isEqual } from "lodash";
+import * as React from "react";
+import { useSyncExternalStoreWithSelector } from "use-sync-external-store/with-selector";
+
+const CUSTOM_STORAGE_EVENT_NAME = "@kablamo/kerosene-ui/storage";
+
+export interface CustomStorageEventInit {
+  readonly key: string | null;
+  readonly newValue: string | null;
+  readonly storageArea: Storage | null;
+}
+
+declare global {
+  interface WindowEventMap {
+    [CUSTOM_STORAGE_EVENT_NAME]: CustomEvent<CustomStorageEventInit>;
+  }
+}
+
+const getServerSnapshot = () => null;
+
+/**
+ * Custom hook which allows reading/writing of `localStorage` in a manner similar to `React.useState`
+ * @param key localStorage key
+ * @param defaultValue Value used when `localStorage` contains an empty or invalid value
+ * @param isT Type guard function which checks that the parsed value from `localStorage` is of type `T`
+ */
+export default function useLocalStorage<T>(
+  key: string,
+  defaultValue: T,
+  isT: (value: unknown) => value is T,
+) {
+  const subscribe = React.useCallback(
+    (callback: () => void) => {
+      const onCustomStorageEvent = (e: CustomEvent<CustomStorageEventInit>) => {
+        if (
+          e.detail.storageArea !== window.localStorage ||
+          e.detail.key !== key
+        )
+          return;
+        callback();
+      };
+
+      const onStorageEvent = (e: StorageEvent) => {
+        if (e.storageArea !== window.localStorage || e.key !== key) return;
+        callback();
+      };
+
+      window.addEventListener(CUSTOM_STORAGE_EVENT_NAME, onCustomStorageEvent);
+      window.addEventListener("storage", onStorageEvent);
+      return () => {
+        window.removeEventListener(
+          CUSTOM_STORAGE_EVENT_NAME,
+          onCustomStorageEvent,
+        );
+        window.removeEventListener("storage", onStorageEvent);
+      };
+    },
+    [key],
+  );
+
+  const getSnapshot = React.useCallback(() => {
+    // In React 16 & 17, the `useSyncExternalStore` shim always uses `getSnapshot()`, even on the server
+    if (
+      typeof window === "undefined" ||
+      typeof window.localStorage === "undefined"
+    ) {
+      return null;
+    }
+
+    return window.localStorage.getItem(key);
+  }, [key]);
+
+  const selector = React.useCallback(
+    (stored: string | null) => {
+      try {
+        const parsed = stored ? (JSON.parse(stored) as unknown) : defaultValue;
+        return isT(parsed) ? parsed : defaultValue;
+      } catch (error) {
+        return defaultValue;
+      }
+    },
+    [defaultValue, isT],
+  );
+
+  const state = useSyncExternalStoreWithSelector(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+    selector,
+    isEqual,
+  );
+
+  const setValue = React.useCallback(
+    (value: React.SetStateAction<T>) => {
+      const newValue = JSON.stringify(
+        // @ts-expect-error
+        typeof value === "function" ? value(selector(getSnapshot())) : value,
+      );
+
+      window.localStorage.setItem(key, newValue);
+      window.dispatchEvent(
+        new CustomEvent<CustomStorageEventInit>(CUSTOM_STORAGE_EVENT_NAME, {
+          cancelable: false,
+          detail: {
+            key,
+            newValue,
+            storageArea: window.localStorage,
+          },
+        }),
+      );
+    },
+    [getSnapshot, key, selector],
+  );
+
+  return [state, setValue] as const;
+}

--- a/packages/kerosene-ui/src/hooks/usePageVisibility.spec.tsx
+++ b/packages/kerosene-ui/src/hooks/usePageVisibility.spec.tsx
@@ -34,7 +34,6 @@ describe("usePageVisibility", () => {
     expect(addEventListener).toHaveBeenCalledWith(
       "visibilitychange",
       expect.any(Function),
-      false,
     );
     const onVisibilityChange = addEventListener.mock.calls.find(
       (call) => call[0] === "visibilitychange",
@@ -50,7 +49,6 @@ describe("usePageVisibility", () => {
     expect(removeEventListener).toHaveBeenCalledWith(
       "visibilitychange",
       onVisibilityChange,
-      false,
     );
   });
 
@@ -63,7 +61,6 @@ describe("usePageVisibility", () => {
     expect(addEventListener).toHaveBeenCalledWith(
       "visibilitychange",
       expect.any(Function),
-      false,
     );
     const onVisibilityChange = addEventListener.mock.calls.find(
       (call) => call[0] === "visibilitychange",
@@ -79,7 +76,6 @@ describe("usePageVisibility", () => {
     expect(removeEventListener).toHaveBeenCalledWith(
       "visibilitychange",
       onVisibilityChange,
-      false,
     );
   });
 

--- a/packages/kerosene-ui/src/index.ts
+++ b/packages/kerosene-ui/src/index.ts
@@ -6,6 +6,10 @@ export {
 export { default as useInterval } from "./hooks/useInterval";
 export { default as useIsomorphicLayoutEffect } from "./hooks/useIsomorphicLayoutEffect";
 export { default as useKonamiCode } from "./hooks/useKonamiCode";
+export {
+  default as useLocalStorage,
+  type CustomStorageEventInit,
+} from "./hooks/useLocalStorage";
 export { default as useMediaQuery } from "./hooks/useMediaQuery";
 export { default as useMergedRefs } from "./hooks/useMergedRefs";
 export { default as usePageVisibility } from "./hooks/usePageVisibility";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2001,6 +2001,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
   integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
 
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -6496,6 +6501,11 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 v8-to-istanbul@^9.0.1:
   version "9.1.0"


### PR DESCRIPTION
- [x] Remove EOL `lts/fermium` from GitHub workflows
- [x] Add `use-sync-external-store` dependency to allow continued support of React 16 & 17 with `useSyncExternalStore` shim
- [x] Add `useLocalStorage` hook
- [x] Add `useCurrentTime` hook
- [x] Update `useMediaQuery` to use `useSyncExternalStore`
- [x] Update `usePageVisibility` to use `useSyncExternalStore`
- [x] Bump version of `@kablamo/kerosene-ui` for release