### PR TITLE
eslint-config: Disable naming-convention rule for non-js and non-ts files.

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -68,71 +68,6 @@ module.exports = {
     // @typescript-eslint rules
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
-    "@typescript-eslint/naming-convention": [
-      "error",
-      // camelCase is the default
-      {
-        selector: "default",
-        format: ["camelCase"],
-        leadingUnderscore: "allowSingleOrDouble",
-        trailingUnderscore: "allowSingleOrDouble",
-      },
-      // imports should be camelCase or PascalCase
-      {
-        selector: "import",
-        format: ["camelCase", "PascalCase"],
-        leadingUnderscore: "allowSingleOrDouble",
-        trailingUnderscore: "allowSingleOrDouble",
-      },
-      // variables can be camelCase, PascalCase, or UPPER_CASE
-      {
-        selector: "variable",
-        format: ["camelCase", "PascalCase", "UPPER_CASE"],
-        leadingUnderscore: "allowSingleOrDouble",
-        trailingUnderscore: "allowSingleOrDouble",
-      },
-      // destructuring variables from 3rd party sources which do not follow our naming conventions is okay
-      { selector: "variable", format: null, modifiers: ["destructured"] },
-      // functions should be camelCase or PascalCase
-      {
-        selector: "function",
-        format: ["camelCase", "PascalCase"],
-        leadingUnderscore: "allowSingleOrDouble",
-        trailingUnderscore: "allowSingleOrDouble",
-      },
-      // types should be PascalCase
-      {
-        selector: "typeLike",
-        format: ["PascalCase"],
-        leadingUnderscore: "allowSingleOrDouble",
-        trailingUnderscore: "allowSingleOrDouble",
-      },
-      // enum members should be UPPER_CASE
-      {
-        selector: "enumMember",
-        format: ["UPPER_CASE"],
-      },
-      // 3rd party APIs do not always follow our naming conventions
-      {
-        selector: ["method", "parameter", "parameterProperty", "property"],
-        format: null,
-      },
-      // ignore properties that require quotes
-      {
-        selector: [
-          "classProperty",
-          "objectLiteralProperty",
-          "typeProperty",
-          "classMethod",
-          "objectLiteralMethod",
-          "typeMethod",
-          "accessor",
-          "enumMember",
-        ],
-        format: null,
-        modifiers: ["requiresQuotes"],
-      },
-    ],
     "@typescript-eslint/no-non-null-assertion": "off",
 
     // eslint-plugin-import rules
@@ -254,6 +189,92 @@ module.exports = {
         // Declaration merging
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-namespace": "off",
+      },
+    },
+    {
+      files: [
+        "*.js",
+        "*.ts",
+        "*.jsx",
+        "*.tsx",
+        "*.cjs",
+        "*.cts",
+        "*.cjsx",
+        "*.ctsx",
+        "*.mjs",
+        "*.mts",
+        "*.mjsx",
+        "*.mtsx",
+      ],
+      parserOptions: {
+        project: true,
+      },
+      rules: {
+        "@typescript-eslint/naming-convention": [
+          "error",
+          // camelCase is the default
+          {
+            selector: "default",
+            format: ["camelCase"],
+            leadingUnderscore: "allowSingleOrDouble",
+            trailingUnderscore: "allowSingleOrDouble",
+          },
+          // imports should be camelCase or PascalCase
+          {
+            selector: "import",
+            format: ["camelCase", "PascalCase"],
+            leadingUnderscore: "allowSingleOrDouble",
+            trailingUnderscore: "allowSingleOrDouble",
+          },
+          // variables can be camelCase, PascalCase, or UPPER_CASE
+          {
+            selector: "variable",
+            format: ["camelCase", "PascalCase", "UPPER_CASE"],
+            leadingUnderscore: "allowSingleOrDouble",
+            trailingUnderscore: "allowSingleOrDouble",
+          },
+          // destructuring variables from 3rd party sources which do not follow our naming conventions is okay
+          { selector: "variable", format: null, modifiers: ["destructured"] },
+          // functions should be camelCase or PascalCase
+          {
+            selector: "function",
+            format: ["camelCase", "PascalCase"],
+            leadingUnderscore: "allowSingleOrDouble",
+            trailingUnderscore: "allowSingleOrDouble",
+          },
+          // types should be PascalCase
+          {
+            selector: "typeLike",
+            format: ["PascalCase"],
+            leadingUnderscore: "allowSingleOrDouble",
+            trailingUnderscore: "allowSingleOrDouble",
+          },
+          // enum members should be UPPER_CASE
+          {
+            selector: "enumMember",
+            format: ["UPPER_CASE"],
+          },
+          // 3rd party APIs do not always follow our naming conventions
+          {
+            selector: ["method", "parameter", "parameterProperty", "property"],
+            format: null,
+          },
+          // ignore properties that require quotes
+          {
+            selector: [
+              "classProperty",
+              "objectLiteralProperty",
+              "typeProperty",
+              "classMethod",
+              "objectLiteralMethod",
+              "typeMethod",
+              "accessor",
+              "enumMember",
+            ],
+            format: null,
+            modifiers: ["requiresQuotes"],
+          },
+        ],
       },
     },
   ],

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -206,9 +206,6 @@ module.exports = {
         "*.mjsx",
         "*.mtsx",
       ],
-      parserOptions: {
-        project: true,
-      },
       rules: {
         "@typescript-eslint/naming-convention": [
           "error",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/eslint-config",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "main": "index.js",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/eslint-config",
   "bugs": {


### PR DESCRIPTION
Ran into an issue when updating to the latest version of eslint-config:

```
Error: Error while loading rule '@typescript-eslint/naming-convention': You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.
Occurred while linting /Users/will/code/kablamo/os/os-frontend/packages/design-system/src/docs/Cheatsheet.mdx
```

@nhardy found that the naming-convention rule requires type information, so this rule should only be enabled on js and ts files.