### PR TITLE
kerosene-ui: Fix React Query query helpers - isLoading -> isPending

### DIFF
--- a/packages/kerosene-ui/package.json
+++ b/packages/kerosene-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-ui",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene-ui",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"

--- a/packages/kerosene-ui/src/components/Boundaries/helpers.ts
+++ b/packages/kerosene-ui/src/components/Boundaries/helpers.ts
@@ -38,5 +38,5 @@ export function isQueryObserverLoadingErrorResult<
 export function isQueryObserverLoadingResult<TData = unknown, TError = unknown>(
   query: UseQueryResult<TData, TError>,
 ): query is QueryObserverLoadingResult<TData, TError> {
-  return query.data === undefined && query.isLoading;
+  return query.data === undefined && query.isPending;
 }

--- a/packages/kerosene-ui/src/components/Boundaries/testHelpers.ts
+++ b/packages/kerosene-ui/src/components/Boundaries/testHelpers.ts
@@ -1,5 +1,4 @@
 import type {
-  QueryKey,
   QueryObserverBaseResult,
   QueryObserverLoadingErrorResult,
   QueryObserverLoadingResult,
@@ -10,7 +9,7 @@ import type {
 function createQueryObserverBaseResult<
   TData = unknown,
   TError = unknown,
->(): QueryObserverBaseResult<TData, TError> & { queryKey: QueryKey } {
+>(): QueryObserverBaseResult<TData, TError> {
   return {
     data: undefined,
     dataUpdatedAt: 0,
@@ -33,7 +32,6 @@ function createQueryObserverBaseResult<
     isRefetching: false,
     isStale: false,
     isSuccess: false,
-    queryKey: [],
     refetch: jest.fn(),
     status: "pending",
     fetchStatus: "idle",
@@ -42,7 +40,7 @@ function createQueryObserverBaseResult<
 
 export function createQueryObserverSuccessResult<TData, TError = never>(
   data: TData,
-): QueryObserverSuccessResult<TData, TError> & { queryKey: QueryKey } {
+): QueryObserverSuccessResult<TData, TError> {
   return {
     ...createQueryObserverBaseResult<TData, TError>(),
     data,
@@ -60,10 +58,7 @@ export function createQueryObserverSuccessResult<TData, TError = never>(
 export function createQueryObserverRefetchErrorResult<
   TData = unknown,
   TError = unknown,
->(
-  data: TData,
-  error: TError,
-): QueryObserverRefetchErrorResult<TData, TError> & { queryKey: QueryKey } {
+>(data: TData, error: TError): QueryObserverRefetchErrorResult<TData, TError> {
   return {
     ...createQueryObserverBaseResult<TData, TError>(),
     data,
@@ -81,9 +76,7 @@ export function createQueryObserverRefetchErrorResult<
 export function createQueryObserverLoadingErrorResult<
   TData = unknown,
   TError = unknown,
->(
-  error: TError,
-): QueryObserverLoadingErrorResult<TData, TError> & { queryKey: QueryKey } {
+>(error: TError): QueryObserverLoadingErrorResult<TData, TError> {
   return {
     ...createQueryObserverBaseResult<TData, TError>(),
     data: undefined,
@@ -101,7 +94,7 @@ export function createQueryObserverLoadingErrorResult<
 export function createQueryObserverLoadingResult<
   TData = unknown,
   TError = unknown,
->(): QueryObserverLoadingResult<TData, TError> & { queryKey: QueryKey } {
+>(): QueryObserverLoadingResult<TData, TError> {
   return {
     ...createQueryObserverBaseResult<TData, TError>(),
     data: undefined,


### PR DESCRIPTION
These helpers were originally written for React Query v4, and I missed the rename of `isLoading` -> `isPending`, as `isLoading` was not removed but instead now represents something different. See [React Query docs](https://tanstack.com/query/v5/docs/react/guides/migrating-to-v5#status-loading-has-been-changed-to-status-pending-and-isloading-has-been-changed-to-ispending-and-isinitialloading-has-now-been-renamed-to-isloading).