### PR TITLE
kerosene-ui: Prefer rendering error fallback over loading fallback in QueriesBoundary.

### DIFF
--- a/packages/kerosene-ui/package.json
+++ b/packages/kerosene-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-ui",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene-ui",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"

--- a/packages/kerosene-ui/src/components/Boundaries/QueriesBoundary.spec.tsx
+++ b/packages/kerosene-ui/src/components/Boundaries/QueriesBoundary.spec.tsx
@@ -21,6 +21,8 @@ const rejectedPromise = Promise.reject(error);
 // A .catch() handler must be added synchronously to prevent PromiseRejectionUnhandledWarning
 rejectedPromise.catch(noop);
 
+const pendingPromise = new Promise<never>(noop);
+
 describe("QueriesBoundary", () => {
   it.each([
     {
@@ -83,6 +85,15 @@ describe("QueriesBoundary", () => {
       },
       value1: rejectedPromise,
       value2: rejectedPromise,
+    },
+    {
+      expected: "errorFallback",
+      props: {
+        children: "Success",
+        errorFallback: <>errorFallback</>,
+      },
+      value1: rejectedPromise,
+      value2: pendingPromise,
     },
   ] satisfies Array<{
     expected: string;

--- a/packages/kerosene-ui/src/components/Boundaries/QueriesBoundary.tsx
+++ b/packages/kerosene-ui/src/components/Boundaries/QueriesBoundary.tsx
@@ -130,10 +130,6 @@ const QueriesBoundary = <
     [queries],
   );
 
-  if (queries.some((query) => isQueryObserverLoadingResult(query))) {
-    return <>{loadingFallback}</>;
-  }
-
   if (error) {
     if (React.isValidElement(errorFallback)) {
       return <>{errorFallback}</>;
@@ -156,6 +152,10 @@ const QueriesBoundary = <
     throw new Error(
       "QueriesBoundary requires either errorFallback, errorFallbackRender, or ErrorFallbackComponent prop",
     );
+  }
+
+  if (queries.some((query) => isQueryObserverLoadingResult(query))) {
+    return <>{loadingFallback}</>;
   }
 
   return (


### PR DESCRIPTION
Simply re-orders the error/loading check to fix an issue where a dependant query would cause a persistent loading fallback when the first query failed.