### PR TITLE
kerosene: Update date-fns to v4 for @date-fns/tz support via options

### DIFF
--- a/packages/kerosene-test/package.json
+++ b/packages/kerosene-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-test",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene-test",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"
@@ -46,7 +46,7 @@
     "utils"
   ],
   "dependencies": {
-    "@kablamo/kerosene": "^0.0.41",
+    "@kablamo/kerosene": "^0.0.45",
     "lodash": "^4.17.21",
     "sinon": "^19.0.2"
   },

--- a/packages/kerosene-ui/package.json
+++ b/packages/kerosene-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene-ui",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene-ui",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"
@@ -35,12 +35,12 @@
     "node": ">=18.12.0"
   },
   "dependencies": {
-    "@kablamo/kerosene": "^0.0.41",
+    "@kablamo/kerosene": "^0.0.45",
     "lodash": "^4.17.21",
     "use-sync-external-store": "^1.2.2"
   },
   "devDependencies": {
-    "@kablamo/kerosene-test": "^0.0.17",
+    "@kablamo/kerosene-test": "^0.0.18",
     "@kablamo/rollup-plugin-resolve-externals": "^0.0.2",
     "@optimize-lodash/rollup-plugin": "^5.0.0",
     "@sinonjs/fake-timers": "^13.0.5",

--- a/packages/kerosene/package.json
+++ b/packages/kerosene/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kablamo/kerosene",
-  "version": "0.0.41",
+  "version": "0.0.45",
   "repository": "https://github.com/KablamoOSS/kerosene/tree/master/packages/kerosene",
   "bugs": {
     "url": "https://github.com/KablamoOSS/kerosene/issues"
@@ -32,7 +32,7 @@
   "dependencies": {
     "content-type": "^1.0.5",
     "core-js-pure": "^3.39.0",
-    "date-fns": "^3.6.0",
+    "date-fns": "^4.1.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/kerosene/src/datetime/isAfterDay.ts
+++ b/packages/kerosene/src/datetime/isAfterDay.ts
@@ -1,13 +1,20 @@
-import { startOfDay } from "date-fns";
+import { startOfDay, type ContextOptions } from "date-fns";
+
+export type IsAfterDayOptions = ContextOptions<Date>;
 
 /**
  * Returns whether the day of `date` is after the day of `dateToCompare`
  * @param date
  * @param dateToCompare
+ * @param options
  */
 export default function isAfterDay(
   date: Date | number,
   dateToCompare: Date | number,
+  options?: IsAfterDayOptions,
 ): boolean {
-  return startOfDay(date).getTime() > startOfDay(dateToCompare).getTime();
+  return (
+    startOfDay(date, options).getTime() >
+    startOfDay(dateToCompare, options).getTime()
+  );
 }

--- a/packages/kerosene/src/datetime/isBeforeDay.ts
+++ b/packages/kerosene/src/datetime/isBeforeDay.ts
@@ -1,13 +1,20 @@
-import { startOfDay } from "date-fns";
+import { startOfDay, type ContextOptions } from "date-fns";
+
+export type IsBeforeDayOptions = ContextOptions<Date>;
 
 /**
  * Returns whether the day of `date` is before the day of `dateToCompare`
  * @param date
  * @param dateToCompare
+ * @param options
  */
 export default function isBeforeDay(
   date: Date | number,
   dateToCompare: Date | number,
+  options?: IsBeforeDayOptions,
 ): boolean {
-  return startOfDay(date).getTime() < startOfDay(dateToCompare).getTime();
+  return (
+    startOfDay(date, options).getTime() <
+    startOfDay(dateToCompare, options).getTime()
+  );
 }

--- a/packages/kerosene/src/datetime/isSameOrAfterDay.ts
+++ b/packages/kerosene/src/datetime/isSameOrAfterDay.ts
@@ -1,14 +1,21 @@
-import { isSameDay } from "date-fns";
+import { isSameDay, type ContextOptions } from "date-fns";
 import isAfterDay from "./isAfterDay";
+
+export type IsSameOrAfterDayOptions = ContextOptions<Date>;
 
 /**
  * Returns whether the day of `date` is the same or after the day of `dateToCompare`
  * @param date
  * @param dateToCompare
+ * @param options
  */
 export default function isSameOrAfterDay(
   date: Date | number,
   dateToCompare: Date | number,
+  options?: IsSameOrAfterDayOptions,
 ): boolean {
-  return isSameDay(date, dateToCompare) || isAfterDay(date, dateToCompare);
+  return (
+    isSameDay(date, dateToCompare, options) ||
+    isAfterDay(date, dateToCompare, options)
+  );
 }

--- a/packages/kerosene/src/datetime/isSameOrBeforeDay.ts
+++ b/packages/kerosene/src/datetime/isSameOrBeforeDay.ts
@@ -1,14 +1,21 @@
-import { isSameDay } from "date-fns";
+import { isSameDay, type ContextOptions } from "date-fns";
 import isBeforeDay from "./isBeforeDay";
+
+export type IsSameOrBeforeDayOptions = ContextOptions<Date>;
 
 /**
  * Returns whether the day of `date` is the same or before the day of `dateToCompare`
  * @param date
  * @param dateToCompare
+ * @param options
  */
 export default function isSameOrBeforeDay(
   date: Date | number,
   dateToCompare: Date | number,
+  options?: ContextOptions<Date>,
 ): boolean {
-  return isSameDay(date, dateToCompare) || isBeforeDay(date, dateToCompare);
+  return (
+    isSameDay(date, dateToCompare, options) ||
+    isBeforeDay(date, dateToCompare, options)
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2272,10 +2272,10 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-date-fns@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
-  integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"


### PR DESCRIPTION
Updates `date-fns` to v4 for `@date-fns/tz` support. Also adds `options` to functions that can be timezone-aware.

See also: https://blog.date-fns.org/v40-with-time-zone-support/